### PR TITLE
fix: correct webhook endpoint description

### DIFF
--- a/samples/polar.webhook/Controllers/WebhookController.cs
+++ b/samples/polar.webhook/Controllers/WebhookController.cs
@@ -38,7 +38,7 @@ public class WebhookController : ControllerBase
             endpoints = new[]
             {
                 "/api/webhook/test - test endpoint",
-                "/api/webhook/polar - Polar webhook receive"
+                "/api/webhook/polar - Polar webhook receiver"
             }
         });
     }


### PR DESCRIPTION
## Summary
- fix test endpoint description in webhook sample

## Testing
- `dotnet build -c Debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa4463f0883328844c579ad290ebe