### PR TITLE
fix: default BaseUrl to sandbox

### DIFF
--- a/src/Services/PolarClientOptions.cs
+++ b/src/Services/PolarClientOptions.cs
@@ -15,7 +15,7 @@ namespace PolarNet.Services
         /// <summary>
         /// Base URL without trailing /v1. Defaults to sandbox.
         /// </summary>
-        public string BaseUrl { get; set; } = string.Empty;
+        public string BaseUrl { get; set; } = "https://sandbox-api.polar.sh";
         /// <summary>
         /// Default organization ID used for listing/filtering where applicable.
         /// </summary>


### PR DESCRIPTION
## Summary
- default BaseUrl to sandbox API

## Testing
- `dotnet build -c Debug` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa9fd7104833283701f2c456c8124