### PR TITLE
test: verify webhook endpoint test result

### DIFF
--- a/tests/PolarNet.Tests/Integration/PolarSandboxTests.cs
+++ b/tests/PolarNet.Tests/Integration/PolarSandboxTests.cs
@@ -346,7 +346,7 @@ namespace PolarNet.Tests.Integration
                 // Test the webhook endpoint
                 var testResult = await client.TestWebhookEndpointAsync(created.Id);
                 // Note: Test might fail if the URL is not reachable, but the method should work
-                // testResult is a bool (value type), no need for null check
+                Assert.True(testResult, "Testing the webhook endpoint returned false. Ensure the webhook site URL is reachable.");
             }
             finally
             {


### PR DESCRIPTION
## Summary
- assert that TestWebhookEndpointAsync returns true in WebhookEndpoints_Create_Update_Delete_Work

## Testing
- `dotnet test -c Debug` *(fails: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68aaa9ff804883328af4ae90c8042cb2